### PR TITLE
[40] Disallow use of rmw (main)

### DIFF
--- a/packaging/test_rule_engine_plugin_metadata_guard.py
+++ b/packaging/test_rule_engine_plugin_metadata_guard.py
@@ -266,6 +266,27 @@ class Test_Rule_Engine_Plugin_Metadata_Guard(session.make_sessions_mixin(admins,
             # Clean up.
             self.rods.assert_icommand(['imeta', 'rm', '-C', root_coll, self.metadata_guard_attribute_name(), json_config])
 
+    def test_plugin_cannot_be_bypassed_with_addw__issue_40(self):
+        config = IrodsConfig()
+
+        # Set JSON configuration for the root collection.
+        root_coll = os.path.join('/', self.admin.zone_name)
+        json_config = json.dumps({
+            'prefixes': ['irods::'],
+            'admin_only': True
+        })
+        self.rods.assert_icommand(['imeta', 'set', '-C', root_coll, self.metadata_guard_attribute_name(), json_config])
+
+        try:
+            with lib.file_backed_up(config.server_config_path):
+                self.enable_rule_engine_plugin(config)
+
+                self.user.assert_icommand(['imeta', 'addw', '-C', self.user.session_collection, 'irods::addw', 'v'], 'STDERR', ['CAT_INSUFFICIENT_PRIVILEGE_LEVEL'])
+
+        finally:
+            # Clean up.
+            self.rods.assert_icommand(['imeta', 'rm', '-C', root_coll, self.metadata_guard_attribute_name(), json_config])
+
     #
     # Utility Functions
     #

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,13 @@ namespace
 	{
 		try {
 			auto* input = boost::any_cast<modAVUMetadataInp_t*>(*std::next(std::begin(_rule_arguments), 2));
+
+			if (strcmp(input->arg0, "rmw") == 0) {
+				log_re::error({{"log_message", "rmw is deprecated and its usage is disallowed by metadata_guard"},
+				               {"rule_engine_plugin", "metadata_guard"}});
+				return ERROR(SYS_NOT_ALLOWED, "rmw is deprecated and its usage is disallowed by metadata_guard");
+			}
+
 			auto& rei = get_rei(_effect_handler);
 			const auto config = load_plugin_config(rei);
 


### PR DESCRIPTION
It almost is that easy?

Pertinent questions:
1. What error code return should I use for it? Not sure what's most relevant in this case...
2. Should admins still be allowed to use rmw?

New tests for this still pending.
