### PR TITLE
[86] Modify all usages of assertEquals to assertEqual (main)

### DIFF
--- a/packaging/test_rule_engine_plugin_metadata_guard.py
+++ b/packaging/test_rule_engine_plugin_metadata_guard.py
@@ -127,8 +127,8 @@ class Test_Rule_Engine_Plugin_Metadata_Guard(session.make_sessions_mixin(admins,
 
                 def check_metadata():
                     out, err, ec = self.admin.run_icommand(['imeta', 'ls', '-C', coll])
-                    self.assertEquals(ec, 0)
-                    self.assertEquals(len(err), 0)
+                    self.assertEqual(ec, 0)
+                    self.assertEqual(len(err), 0)
                     self.assertTrue('attribute: {0}\nvalue: {1}'.format(attribute_name, 'abc') in out)
                     self.assertTrue('attribute: {0}\nvalue: {1}'.format(attribute_name, 'def') in out)
                     self.assertTrue('attribute: {0}\nvalue: {1}'.format(attribute_name, 'DEF') not in out)
@@ -162,9 +162,9 @@ class Test_Rule_Engine_Plugin_Metadata_Guard(session.make_sessions_mixin(admins,
             self.admin.assert_icommand(['imeta', 'set', '-C', self.admin.session_collection, 'a', 'v'])
             self.admin.assert_icommand(['imeta', 'ls', '-C', self.admin.session_collection], 'STDOUT', ['attribute: a', 'value: v'])
 
-            self.assertEquals(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'error', log_offset), 0)
-            self.assertEquals(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'exception', log_offset), 0)
-            self.assertEquals(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'SYS_CONFIG_FILE_ERR', log_offset), 0)
+            self.assertEqual(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'error', log_offset), 0)
+            self.assertEqual(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'exception', log_offset), 0)
+            self.assertEqual(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'SYS_CONFIG_FILE_ERR', log_offset), 0)
 
     def test_plugin_honors_admin_only_config_option_when_rodsadmins_manipulate_metadata__issue_25(self):
         config = IrodsConfig()


### PR DESCRIPTION
Change all `assertEquals` to `assertEqual` for Ubuntu 24.