### PR TITLE
[irods/externals#263] Update build hook for clang 16 (main)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -14,12 +14,10 @@ def add_cmake_to_front_of_path():
 
 def install_building_dependencies(externals_directory):
     externals_list = [
-        'irods-externals-avro1.11.0-3',
-        'irods-externals-boost1.81.0-1',
-        'irods-externals-clang13.0.1-0',
+        'irods-externals-boost1.81.0-2',
+        'irods-externals-clang16.0.6-0',
         'irods-externals-cmake3.21.4-0',
-        'irods-externals-json3.10.4-0',
-        'irods-externals-libarchive3.5.2-0'
+        'irods-externals-json3.10.4-0'
     ]
 
     if externals_directory == 'None' or externals_directory is None:


### PR DESCRIPTION
In service of irods/externals#263

Do not merge before new externals packages are in the package repos.